### PR TITLE
Fixup nits in the uefi-run script

### DIFF
--- a/scripts/uefi-run.sh
+++ b/scripts/uefi-run.sh
@@ -4,8 +4,13 @@
 
 set -e
 
+if [ $# -ne 1 ] || ! [[ -f $1 && -x $1 ]]; then
+    echo "Usage: $0 <patch to mythril.efi>"
+    exit 1
+fi
+
 rm -r -f _boot.img _mnt
-mkfs.msdos -C _boot.img 51200
+mkfs.fat -C _boot.img 51200
 
 mkdir _mnt
 mount _boot.img _mnt


### PR DESCRIPTION
Very minor nits with the `uefi-run.sh` script.

 - Check the input and do not run if no arg is given
 - `mkfs.msdos` should just be a symlink to `mkfs.fat` (Gentoo users that do not enable the `copmat` USE flag for `dosfstools` don't get `mkfs.msdos`)