### PR TITLE
Minor cleanups

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,5 @@
-use crate::error::{self, Error, Result};
-use crate::memory::{self, GuestAddressSpace, GuestPhysAddr};
-use crate::vmexit::{ExitReason, GuestCpuState, IoInstructionQualification};
+use crate::error::{Error, Result};
+use crate::memory::GuestPhysAddr;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::convert::TryInto;

--- a/src/efialloc.rs
+++ b/src/efialloc.rs
@@ -1,4 +1,4 @@
-use crate::error::{self, Error, Result};
+use crate::error::{Error, Result};
 use crate::memory::PhysFrame;
 use uefi::prelude::ResultExt;
 use uefi::table::boot::{AllocateType, BootServices, MemoryType};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use crate::vmcs;
 use alloc::string::String;
-use core::convert::TryFrom;
 use derive_try_from_primitive::TryFromPrimitive;
 use x86::bits64::rflags;
 use x86::bits64::rflags::RFlags;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,15 @@ fn efi_main(_handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     let mut config = vm::VirtualMachineConfig::new(1024);
 
+    // FIXME: When `load_image` may return an error, log the error.
+    //
     // Map OVMF directly below the 4GB boundary
-    config.load_image(
-        "OVMF.fd".into(),
-        memory::GuestPhysAddr::new((4 * 1024 * 1024 * 1024) - (2 * 1024 * 1024)),
-    );
+    config
+        .load_image(
+            "OVMF.fd".into(),
+            memory::GuestPhysAddr::new((4 * 1024 * 1024 * 1024) - (2 * 1024 * 1024)),
+        )
+        .unwrap_or(());
     config.register_device(device::ComDevice::new(0x3F8));
     config.register_device(device::ComDevice::new(0x402)); // The qemu debug port
     config.register_device(device::PciRootComplex::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,4 @@ fn efi_main(_handle: Handle, system_table: SystemTable<Boot>) -> Status {
     info!("Constructed VM!");
 
     vm.launch(vmx).expect("Failed to launch vm");
-
-    loop {}
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,7 +1,6 @@
 use crate::efialloc::FrameAllocator;
-use crate::error::{self, Error, Result};
+use crate::error::{Error, Result};
 use bitflags::bitflags;
-use core::convert::TryFrom;
 use core::ops::{Index, IndexMut};
 use core::ptr::NonNull;
 use derive_try_from_primitive::TryFromPrimitive;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -305,7 +305,7 @@ impl VirtualMachine {
         //TODO: get actual EFER (use MSR for vt-x v1)
         vmcs.write_field(vmcs::VmcsField::GuestIa32Efer, 0x00)?;
 
-        let (guest_cr0, guest_cr4) = unsafe {
+        let (guest_cr0, guest_cr4) = {
             let mut cr0_fixed0 = unsafe { msr::rdmsr(msr::IA32_VMX_CR0_FIXED0) };
             cr0_fixed0 &= !(1 << 0); // disable PE
             cr0_fixed0 &= !(1 << 31); // disable PG

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -470,7 +470,7 @@ impl VirtualMachineRunning {
                     _ => return Err(Error::InvalidValue(format!("Unsupported CR number access"))),
                 }
 
-                self.skip_emulated_instruction();
+                self.skip_emulated_instruction()?;
             }
 
             vmexit::BasicExitReason::CpuId => {
@@ -483,7 +483,7 @@ impl VirtualMachineRunning {
                 guest_cpu.rbx = res.ebx as u64 | (guest_cpu.rbx & 0xffffffff00000000);
                 guest_cpu.rcx = res.ecx as u64 | (guest_cpu.rcx & 0xffffffff00000000);
                 guest_cpu.rdx = res.edx as u64 | (guest_cpu.rdx & 0xffffffff00000000);
-                self.skip_emulated_instruction();
+                self.skip_emulated_instruction()?;
             }
             vmexit::BasicExitReason::IoInstruction => {
                 let (port, input, size) = match exit.information {
@@ -506,7 +506,7 @@ impl VirtualMachineRunning {
                     guest_cpu.rax &= (!guest_cpu.rax) << (size * 8);
                     guest_cpu.rax |= u32::from_be_bytes(out) as u64;
                 }
-                self.skip_emulated_instruction();
+                self.skip_emulated_instruction()?;
             }
             _ => info!("No handler for exit reason: {:?}", exit),
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -190,8 +190,6 @@ impl VirtualMachine {
         for i in 0..8192 {
             let mut host_frame = alloc.allocate_frame()?;
 
-            let frame_ptr = host_frame.start_address().as_u64() as *mut u8;
-
             guest_space.map_frame(
                 alloc,
                 memory::GuestPhysAddr::new((i as u64 * 4096) as u64),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,13 +3,12 @@ use crate::efialloc::FrameAllocator;
 use crate::error::{self, Error, Result};
 use crate::memory::{self, GuestAddressSpace, GuestPhysAddr};
 use crate::percpu;
-use crate::registers::{self, GdtrBase, IdtrBase};
+use crate::registers::{GdtrBase, IdtrBase};
 use crate::{vmcs, vmexit, vmx};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use uefi::{self, table::boot::BootServices};
-use x86::bits64::segmentation::{rdfsbase, rdgsbase};
 use x86::controlregs::{cr0, cr3, cr4};
 use x86::msr;
 

--- a/src/vmcs.rs
+++ b/src/vmcs.rs
@@ -418,7 +418,7 @@ impl ActiveVmcs {
 impl fmt::Display for ActiveVmcs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let read_field = |field: VmcsField| -> core::result::Result<u64, fmt::Error> {
-            self.read_field(field).map_err(|e| fmt::Error)
+            self.read_field(field).map_err(|_| fmt::Error)
         };
 
         write!(f, "VMCS:\n")?;

--- a/src/vmx.rs
+++ b/src/vmx.rs
@@ -1,8 +1,6 @@
 use crate::efialloc::FrameAllocator;
 use crate::error::{self, Error, Result};
-use crate::memory::{self, PhysFrame};
-use crate::{vm, vmcs, vmexit};
-use core::convert::TryFrom;
+use crate::memory::PhysFrame;
 use raw_cpuid::CpuId;
 use x86::msr;
 


### PR DESCRIPTION
 - Cleanup `vmxon_region` on `vmxon` instruction error
 - Fix some warnings
   - Remove some unused imports
   - Fix some unused results
   - Fix unreachable code warning
   - Remove an unneeded `unsafe` block
   - Fix some unused value warnings.