### PR TITLE
build: Escape colons in qemu extra arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ multiboot2_binary = target/$(MULTIBOOT2_TARGET)/debug/mythril_multiboot2
 mythril_src = $(shell find . -type f -name '*.rs' -or -name '*.S' -or -name '*.ld')
 
 ifneq (,$(filter qemu%, $(firstword $(MAKECMDGOALS))))
-    QEMU_EXTRA := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+    QEMU_EXTRA := $(subst :,\:, $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
     $(eval $(QEMU_EXTRA):;@:)
 endif
 


### PR DESCRIPTION
Some options in qemu may contain colons in the value e.g.

 -serial file:foo.txt

We need to escape these colons in the make goals before evaluating.

Fixes: #32 