### PR TITLE
Add DeviceMap device conflict detection.

### DIFF
--- a/mythril_core/src/error.rs
+++ b/mythril_core/src/error.rs
@@ -77,6 +77,7 @@ pub enum Error {
     NotSupported,
     Uefi(String),
     InvalidValue(String),
+    InvalidDevice(String),
     NotImplemented(String),
 }
 


### PR DESCRIPTION
- Add checks to `DeviceMap::register_device` for detecting existing mappings by another device in the map.
- Add `InvalidDevice` to `mythril_core::error::Error`.

fixes #27 